### PR TITLE
feat: default scanAllItems to true on GET /rss

### DIFF
--- a/src/domain/rss/rss.service.spec.ts
+++ b/src/domain/rss/rss.service.spec.ts
@@ -69,7 +69,7 @@ describe('RssService', () => {
     it('should call enqueueScan when isScan is true', async () => {
       const { service, scanJobService } = await buildModule()
       await service.list({ term: 'One Piece S01', isScan: 'true' })
-      expect(scanJobService.enqueueScan).toHaveBeenCalledWith('One Piece', { scanAllItems: false })
+      expect(scanJobService.enqueueScan).toHaveBeenCalledWith('One Piece', { scanAllItems: true })
     })
 
     it('should not call enqueueScan when isScan is false', async () => {

--- a/src/domain/rss/rss.service.ts
+++ b/src/domain/rss/rss.service.ts
@@ -24,7 +24,7 @@ export class RssService {
     scanAllItems?: string | boolean
     isScan?: string | boolean
   }) {
-    const { scanAllItems, isScan = true } = data
+    const { scanAllItems = true, isScan = true } = data
     let term = data.q ?? data.term
     if (term) term = term.replace(/ [sS]\d{1,}(.*)/g, '')
 


### PR DESCRIPTION
## Summary

- `scanAllItems` agora tem `true` como valor padrão quando não informado no endpoint `GET /rss` e `GET /rss/json`
- Atualizado o teste unitário para refletir o novo comportamento padrão

## Test plan

- [x] Testes unitários passando (`rss.service.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)