### PR TITLE
fix: handle colon in RSS scan job ID and guard enqueueScan errors

### DIFF
--- a/src/domain/extractor/scan-job.service.ts
+++ b/src/domain/extractor/scan-job.service.ts
@@ -25,7 +25,7 @@ export class ScanJobService {
       'scan',
       { term, ...options },
       {
-        jobId: `scan-${term}`,
+        jobId: `scan-${term?.replace(/:/g, '-')}`,
         removeOnComplete: true,
       }
     )

--- a/src/domain/rss/rss.service.spec.ts
+++ b/src/domain/rss/rss.service.spec.ts
@@ -78,6 +78,16 @@ describe('RssService', () => {
       expect(scanJobService.enqueueScan).not.toHaveBeenCalled()
     })
 
+    it('should return items even when enqueueScan throws', async () => {
+      const scanJobService = makeScanJobService()
+      ;(scanJobService.enqueueScan as jest.Mock).mockRejectedValue(new Error('Custom Id cannot contain :'))
+      const repository = makeRssRepo()
+      ;(repository.list as jest.Mock).mockResolvedValue([{ id: 1, magnet: 'magnet:?xt=urn:btih:abc', title: 'Re:Zero' }])
+      const { service } = await buildModule({ scanJobService, repository })
+      const result = await service.list({ term: 'Re:Zero', isScan: 'true' })
+      expect(result).toHaveLength(1)
+    })
+
     it('should return empty array when repository returns empty', async () => {
       const { service } = await buildModule()
       const result = await service.list({ isScan: false })

--- a/src/domain/rss/rss.service.ts
+++ b/src/domain/rss/rss.service.ts
@@ -31,7 +31,11 @@ export class RssService {
     this.logger.log(`List -> with term ${term}`)
 
     if (term && (isScan === 'true' || isScan === true)) {
-      await this.scanJobService.enqueueScan(term, { scanAllItems: scanAllItems === 'true' || scanAllItems === true })
+      try {
+        await this.scanJobService.enqueueScan(term, { scanAllItems: scanAllItems === 'true' || scanAllItems === true })
+      } catch (error) {
+        this.logger.warn(`enqueueScan failed: ${(error as Error)?.message}`)
+      }
     }
 
     const response = await this.repository.list({ term, limit: term ? undefined : 100 })


### PR DESCRIPTION
## Summary

- **Preventive**: Sanitize `term` before using as BullMQ job ID — replaces `:` with `-` to avoid `Custom Id cannot contain :` error (e.g., terms like `Re:Zero`)
- **Resilient**: Wrap `enqueueScan` call in `RssService.list()` with try-catch so enqueue failures are logged as warnings and never crash the `/rss` endpoint
- **Test**: Added unit test verifying `/rss` still returns items when `enqueueScan` throws

## Test plan

- [ ] `npm run test:ci` passes
- [ ] Hit `GET /rss?q=Re:Zero` — should return XML without 500 error
- [ ] Verify BullMQ job is created with ID `scan-Re-Zero` (colon replaced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)